### PR TITLE
Upgraded versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "swagger-ui",
     "rocket-swagger-ui",

--- a/swagger-ui/Cargo.toml
+++ b/swagger-ui/Cargo.toml
@@ -19,20 +19,20 @@ rocket = ["rocket-swagger-ui"]
 # actix-web = ["actix-web-swagger-ui"]
 
 [dependencies]
-rust-embed = { version = "5.9.0", features = ["interpolate-folder-path"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.64"
-bytes = "1.5.0"
+rust-embed = { version = "~8", features = ["interpolate-folder-path"] }
+serde = { version = "~1", features = ["derive"] }
+serde_json = "~1"
+bytes = "~1"
 
 rocket-swagger-ui = { version = "0.1", optional = true }
 # actix-web-swagger-ui = { version = "0.1", optional = true }
 
 [build-dependencies]
-reqwest = { version = "0.11.20", features = ["json", "stream", "rustls"] }
-futures = "0.3.28"
-futures-executor = "0.3.28"
+reqwest = { version = "~0.12", features = ["json", "stream", "rustls-tls"] }
+futures = "~0.3"
+futures-executor = "~0.3"
 tokio = { version = "1.32.0", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-anyhow = "1.0.75"
-async-recursion = "1.0.5"
+serde = { version = "~1", features = ["derive"] }
+serde_json = "~1"
+anyhow = "~1"
+async-recursion = "~1"

--- a/swagger-ui/src/lib.rs
+++ b/swagger-ui/src/lib.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
-use rust_embed::RustEmbed;
-use serde::{Deserialize, Serialize};
 
 pub use bytes::Bytes;
+use rust_embed::RustEmbed;
+use serde::Deserialize;
+use serde::Serialize;
 
 /// Assets from swagger-ui-dist
 #[derive(RustEmbed)]
@@ -66,14 +67,14 @@ pub struct Spec {
     /// Spec file name
     pub name: Cow<'static, str>,
     /// Spec file content
-    pub content: Bytes
+    pub content: Bytes,
 }
 
 /// Helper type to accept both provided or existing spec
 #[derive(Debug, Clone)]
 pub enum SpecOrUrl {
     Spec(Spec),
-    Url(Cow<'static, str>)
+    Url(Cow<'static, str>),
 }
 
 impl From<Spec> for SpecOrUrl {
@@ -101,7 +102,7 @@ macro_rules! swagger_spec_file {
     ($name: literal) => {
         $crate::Spec {
             name: std::borrow::Cow::Borrowed(($name).split("/").last().unwrap()),
-            content: $crate::Bytes::from_static(include_bytes!($name))
+            content: $crate::Bytes::from_static(include_bytes!($name)),
         }
     };
 }
@@ -189,7 +190,6 @@ impl Default for Config {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use crate::Assets;
 
     fn asset_list() -> [&'static str; 8] {
@@ -211,7 +211,7 @@ mod tests {
         for asset in &asset_list() {
             println!("\t{}", asset);
             let data = Assets::get(&asset).unwrap();
-            assert!(!data.is_empty());
+            assert!(!data.data.is_empty());
         }
     }
 


### PR DESCRIPTION
My cargo-deny failed on `rust-embed` because https://rustsec.org/advisories/RUSTSEC-2021-0126.html, so I upgraded the versions